### PR TITLE
Add debuginfo to exception & nicer formatting

### DIFF
--- a/moodle/exception.py
+++ b/moodle/exception.py
@@ -11,7 +11,7 @@ class MoodleException(Exception):
     debuginfo: Optional[str] = ""
 
     def __str__(self):
-        return "Error Code: {}\nException: {}\n Message: {}\n Debug Info: {}".format(
+        return "Error Code: {}\nException: {}\nMessage: {}\nDebug Info: {}".format(
             self.message, self.exception, self.errorcode, self.debuginfo)
 
 

--- a/moodle/exception.py
+++ b/moodle/exception.py
@@ -8,9 +8,11 @@ class MoodleException(Exception):
     errorcode: Optional[Any] = ""
     exception: Optional[Any] = ""
     message: Optional[str] = ""
+    debuginfo: Optional[str] = ""
 
     def __str__(self):
-        return self.message or self.exception or self.errorcode
+        return "Error Code: {}\nException: {}\n Message: {}\n Debug Info: {}".format(
+            self.message, self.exception, self.errorcode, self.debuginfo)
 
 
 class BaseException(Exception):


### PR DESCRIPTION
I got the following error when Moodle reported an error:

```
  File "moodle/mdl.py", line 65, in post
    return self.process_response(data)
  File "moodle/mdl.py", line 79, in process_response
    raise MoodleException(**data)  # type: ignore
TypeError: MoodleException.__init__() got an unexpected keyword argument 'debuginfo'
```

Add `debuginfo` to MoodleException and show all possible error information for the user.

The output now looks like this:
```
  File "moodle/mdl.py", line 65, in post
    return self.process_response(data)
  File "moodle/mdl.py", line 79, in process_response
    raise MoodleException(**data)  # type: ignore
moodle.exception.MoodleException: Error Code: Access Control Exception
Exception: webservice_access_exception
Message: accessexception
Debug Info: Access to the function core_course_get_course_module() is not allowed.
                     There could be multiple reasons for this:
                     1. The service linked to the user token does not contain the function.
                     2. The service is user-restricted and the user is not listed.
                     3. The service is IP-restricted and the user IP is not listed.
                     4. The service is time-restricted and the time has expired.
                     5. The token is time-restricted and the time has expired.
                     6. The service requires a specific capability which the user does not have.
                     7. The function is called with username/password (no user token is sent)
                     and none of the services has the function to allow the user.
                     These settings can be found in Administration > Site administration
                     > Server > Web services > External services and Manage tokens.
```