### PR TITLE
Fix to_dict()

### DIFF
--- a/moodle/utils/helper.py
+++ b/moodle/utils/helper.py
@@ -7,46 +7,41 @@ from moodle.attr import asdict as asdict_attr
 T = TypeVar("T")
 
 
-def to_dict(data: Any, name: str = "") -> Any:
+def to_dict(data: dict, name: str = "") -> dict:
     """Properly format query string for webservice request
+    The passed object itself must be a dict, but the returned value will be
+    flattened to a dict with keys like `name[key]` or `name[index][key]`.
 
     Args:
-        data (Any): Query to be formated
+        data (dict): Query to be formated
         name (str, optional): The key of the data. Defaults to "".
 
     Returns:
-        Any: Formated data
+        dict: Formated data
     """
-    if not data:
-        return data
-    if isinstance(data, list):
-        out = {}
-        for idx, val in enumerate(data):
-            val = to_dict(val)
-            if isinstance(val, dict):
-                for key, value in val.items():
-                    out[f"{name}[{idx}][{key}]"] = val[key]
-            else:
-                out_key = name
-                # Check if data required name prefix
-                if hasattr(data, "name"):
-                    out_key += f"[{getattr(data, 'name')}]"
-                out_key += f"[{idx}]"
-                out[out_key] = val
-        return out
-    if isinstance(data, dict):
-        out = {}
-        for key, value in data.items():
-            if isinstance(value, list):
-                out.update(to_dict(value, key))
-            else:
-                out[key] = value
-        return out
-    if has(data):
-        return asdict_attr(data)
-    if isinstance(data, datetime):
-        return datetime.timestamp(data)
-    return data
+
+    result = {}
+    def inner(prefix: str, data: Any) -> dict:
+        pairs = None
+        if isinstance(data, list):
+            pairs = enumerate(data)
+        elif isinstance(data, dict):
+            pairs = data.items()
+        elif has(data):
+            pairs = asdict_attr(data).items()
+
+        if pairs is not None:
+            for key, value in pairs:
+                inner(f"{prefix}[{key}]", value)
+        else:
+            if isinstance(data, datetime):
+                data = datetime.timestamp(data)
+            result[prefix] = data
+
+    for key, value in data.items():
+        inner(key, value)
+
+    return result
 
 
 def fromtimestamp(d: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def domain() -> str:
 @fixture
 def moodle(domain: str) -> Moodle:
     username = "manager"
-    password = "moodle2024"
+    password = "moodle25"
     return Moodle.login(domain, username, password)
 
 

--- a/tests/test_core/test_calendar.py
+++ b/tests/test_core/test_calendar.py
@@ -39,7 +39,7 @@ class TestCalendar:
         pass
 
     def test_get_calendar_events(self, moodle):
-        events = moodle.core.calendar.get_calendar_events()
+        events = moodle.core.calendar.get_calendar_events(options=Events.Options(userevents=1))
         assert isinstance(events, Events)
 
     def test_get_calendar_monthly_view(self, moodle):

--- a/tests/test_utils/test_helper.py
+++ b/tests/test_utils/test_helper.py
@@ -42,8 +42,8 @@ class TestHelper:
             y = attr.ib()
 
         # attr class
-        result = to_dict(MyAttrClass(x=1, y=2))
-        assert result == { 'x': 1, 'y': 2 }
+        # result = to_dict(MyAttrClass(x=1, y=2))
+        # assert result == { 'x': 1, 'y': 2 }
 
         # dict with attr class
         result = to_dict(dict(a=MyAttrClass(x=1, y=2)))

--- a/tests/test_utils/test_helper.py
+++ b/tests/test_utils/test_helper.py
@@ -22,19 +22,19 @@ class TestHelper:
         assert result == { 'a[0][x]': 1, 'a[1][x]': 2, 'b[0][y]': 2, 'b[0][z]': 3 }
 
         # dict with nested dicts
-        # result = to_dict(dict(a=dict(x=1, y=2), b=dict(z=3)))
-        # assert result == { 'a[x]': 1, 'a[y]': 2, 'b[z]': 3 }
+        result = to_dict(dict(a=dict(x=1, y=2), b=dict(z=3)))
+        assert result == { 'a[x]': 1, 'a[y]': 2, 'b[z]': 3 }
 
         # dict with lists of lists
-        # result = to_dict(dict(a=[[1, 2], [3, 4]], b=[[5], [6, 7]]))
-        # assert result == {
-        #     'a[0][0]': 1, 'a[0][1]': 2, 'a[1][0]': 3, 'a[1][1]': 4,
-        #     'b[0][0]': 5, 'b[1][0]': 6, 'b[1][1]': 7,
-        # }
+        result = to_dict(dict(a=[[1, 2], [3, 4]], b=[[5], [6, 7]]))
+        assert result == {
+            'a[0][0]': 1, 'a[0][1]': 2, 'a[1][0]': 3, 'a[1][1]': 4,
+            'b[0][0]': 5, 'b[1][0]': 6, 'b[1][1]': 7,
+        }
 
         # dict with list of nested dicts
-        # result = to_dict(dict(a=[dict(x=1, nested=dict(y=2))]))
-        # assert result == { 'a[0][x]': 1, 'a[0][nested][y]': 2 }
+        result = to_dict(dict(a=[dict(x=1, nested=dict(y=2))]))
+        assert result == { 'a[0][x]': 1, 'a[0][nested][y]': 2 }
 
         @attr.s
         class MyAttrClass:
@@ -46,12 +46,12 @@ class TestHelper:
         assert result == { 'x': 1, 'y': 2 }
 
         # dict with attr class
-        # result = to_dict(dict(a=MyAttrClass(x=1, y=2)))
-        # assert result == { 'a[x]': 1, 'a[y]': 2 }
+        result = to_dict(dict(a=MyAttrClass(x=1, y=2)))
+        assert result == { 'a[x]': 1, 'a[y]': 2 }
 
         # dict with datetime
-        # result = to_dict(dict(a=datetime(2025, 1, 1)))
-        # assert result == { 'a': datetime(2025, 1, 1).timestamp() }
+        result = to_dict(dict(a=datetime(2025, 1, 1)))
+        assert result == { 'a': datetime(2025, 1, 1).timestamp() }
 
         # dict with list of datetimes
         result = to_dict(dict(a=[datetime(2025, 1, 1)]))

--- a/tests/test_utils/test_helper.py
+++ b/tests/test_utils/test_helper.py
@@ -1,0 +1,61 @@
+import attr
+from datetime import datetime
+
+from moodle.utils.helper import to_dict
+
+class TestHelper:
+    def test_to_dict(self):
+        # empty dict
+        result = to_dict(dict())
+        assert result == {}
+
+        # dict with simple values
+        result = to_dict(dict(a=1, b=2))
+        assert result == { 'a': 1, 'b': 2 }
+
+        # dict with lists
+        result = to_dict(dict(a=[1], b=[2, 3]))
+        assert result == { 'a[0]': 1, 'b[0]': 2, 'b[1]': 3 }
+
+        # dict with lists of dicts
+        result = to_dict(dict(a=[dict(x=1), dict(x=2)], b=[dict(y=2, z=3)]))
+        assert result == { 'a[0][x]': 1, 'a[1][x]': 2, 'b[0][y]': 2, 'b[0][z]': 3 }
+
+        # dict with nested dicts
+        # result = to_dict(dict(a=dict(x=1, y=2), b=dict(z=3)))
+        # assert result == { 'a[x]': 1, 'a[y]': 2, 'b[z]': 3 }
+
+        # dict with lists of lists
+        # result = to_dict(dict(a=[[1, 2], [3, 4]], b=[[5], [6, 7]]))
+        # assert result == {
+        #     'a[0][0]': 1, 'a[0][1]': 2, 'a[1][0]': 3, 'a[1][1]': 4,
+        #     'b[0][0]': 5, 'b[1][0]': 6, 'b[1][1]': 7,
+        # }
+
+        # dict with list of nested dicts
+        # result = to_dict(dict(a=[dict(x=1, nested=dict(y=2))]))
+        # assert result == { 'a[0][x]': 1, 'a[0][nested][y]': 2 }
+
+        @attr.s
+        class MyAttrClass:
+            x = attr.ib()
+            y = attr.ib()
+
+        # attr class
+        result = to_dict(MyAttrClass(x=1, y=2))
+        assert result == { 'x': 1, 'y': 2 }
+
+        # dict with attr class
+        # result = to_dict(dict(a=MyAttrClass(x=1, y=2)))
+        # assert result == { 'a[x]': 1, 'a[y]': 2 }
+
+        # dict with datetime
+        # result = to_dict(dict(a=datetime(2025, 1, 1)))
+        # assert result == { 'a': datetime(2025, 1, 1).timestamp() }
+
+        # dict with list of datetimes
+        result = to_dict(dict(a=[datetime(2025, 1, 1)]))
+        assert result == { 'a[0]': datetime(2025, 1, 1).timestamp() }
+
+    def test_fromtimestamp(self):
+        pass


### PR DESCRIPTION
Fixes #23, based on #24 for obvious reasons

Note that `test_core/test_grades.py` is currently failing, even before this PR -- maybe something to do with Moodle 5.0 compatibility?

This PR reimplements `to_dict()` and changes some behavior that was not depended upon:
- Due to recursion, the function could previously accept any value and also accept a `name` parameter. The actual recursion is now in a nested function, so I
  - removed the `name` parameter.
  - require that the passed data are a dictionary. A HTTP request always has named parameters, only the nested values will eventually not be dicts

  This means that you can't pass a `@attr.s` class directly to the function. You can see the commented regressed test case here:
  https://github.com/hexatester/moodlepy/blob/6e580f177e11dea58abd869e1037d711b3e1df31/tests/test_utils/test_helper.py#L44-L46
  If you have concerns about this, I can of course also handle this case.
- I didn't know what the purpose of these lines were so I didn't preserve them:
  https://github.com/hexatester/moodlepy/blob/760fb0c5a49b3bcba3fe1e218fae0883b68dc9f1/moodle/utils/helper.py#L31-L33
  because of this, I have marked this PR as a draft. It hasn't caused regressions, though.

You can take a look at cd3d9595 to see what previously failing test cases now succeed. Additionally, in 2e552b80 I edited the test case to fail as described in #23.

Beyond that one calendar test case, I have _not_ tested that the new behavior matches PHP's expectations of form encoded data, so I'd ask you to look over the test cases.