### PR TITLE
add file upload method

### DIFF
--- a/moodle/exception.py
+++ b/moodle/exception.py
@@ -37,6 +37,11 @@ class InvalidCredentialException(BaseException):
 
 
 @dataclass
+class UploadUrlException(BaseException):
+    message: str = "File Upload URL can not be determined!"
+
+
+@dataclass
 class NetworkMoodleException(BaseException):
     """Moodle wrapper for network related network error"""
 

--- a/moodle/mdl.py
+++ b/moodle/mdl.py
@@ -99,6 +99,52 @@ class Mdl:
             return self.process_response(data)
         return res.text
 
+    def post_upload(
+        self, *files,
+        moodlewsrestformat="json",
+        itemid: int = 0, filepath: str = "/"
+    ) -> Any:
+        """Send post request to file upload endpoint.
+
+        Args:
+            files (file-like-objects, multiple): The files to upload.
+            moodlewsrestformat (str, optional): Expected format. Defaults to "json".
+            itemid (int, optional): itemid to upload into. Defaults to 0.
+            filepath (str, optional): file path under which to upload. Defaults to '/'.
+
+        Raises:
+            NetworkMoodleException: If request failed
+            EmptyResponseException: If the response empty
+            UploadUrlException: If the upload endpoint URL can't be inferred
+            MoodleException: Error from server
+
+        Returns:
+            Any: Raw data (str) or dict
+        """
+        if not self.url.endswith("/rest/server.php"):
+            raise UploadUrlException()
+
+        params = {
+            "token": self.token,
+            "moodlewsrestformat": moodlewsrestformat,
+            "itemid": itemid,
+            "filepath": filepath,
+        }
+        try:
+            res = self.session.post(
+                self.url.replace("/rest/server.php", "/upload.php"),
+                params=params,
+                files={f"file_{i}": file for i, file in enumerate(files, start=1)},
+            )
+        except RequestException as e:
+            raise NetworkMoodleException(e)
+        if not res.ok or not res.text:
+            raise EmptyResponseException()
+        if res.ok and moodlewsrestformat == "json":
+            data = json.loads(res.text)
+            return self.process_response(data)
+        return res.text
+
     def process_response(self, data: Any) -> Any:
         """Process data to handle exception or warnings
 

--- a/moodle/mdl.py
+++ b/moodle/mdl.py
@@ -166,7 +166,14 @@ class Mdl:
                 elif isinstance(data["warnings"], dict):
                     warning = MoodleWarning(**data["warnings"])  # type: ignore
                     self.logger.warning(str(warning))
-            if "exception" in data or "errorcode" in data:
+            if "error" in data:
+                # upload.php errors are sometimes structured a bit differently
+                error = data.pop("error")
+                data.pop("stacktrace")
+                data.pop("reproductionlink")
+                data["message"] = error
+                raise MoodleException(**data)  # type: ignore
+            elif "exception" in data or "errorcode" in data:
                 raise MoodleException(**data)  # type: ignore
         return data
 

--- a/moodle/moodle.py
+++ b/moodle/moodle.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from moodle.mdl import Mdl
+from moodle.upload import Upload
 
 from moodle.auth import Auth
 from moodle.block import Block
@@ -19,6 +20,11 @@ class Moodle(Mdl):
 
     def __call__(self, wsfunction: str, moodlewsrestformat="json", **kwargs) -> Any:
         return self.post(wsfunction, moodlewsrestformat, **kwargs)
+
+    @property  # type: ignore
+    @lazy
+    def upload(self) -> Upload:
+        return Upload(self)
 
     @property  # type: ignore
     @lazy

--- a/moodle/upload/__init__.py
+++ b/moodle/upload/__init__.py
@@ -1,0 +1,8 @@
+from .file import File
+
+from .upload import Upload
+
+__all__ = [
+    "File",
+    "Upload",
+]

--- a/moodle/upload/file.py
+++ b/moodle/upload/file.py
@@ -1,0 +1,32 @@
+from moodle.attr import dataclass
+
+
+@dataclass
+class File:
+    """File
+
+    Args:
+        component (str): component
+        contextid (int): contextid
+        userid (str): userid
+        filearea (str): filearea
+        filename (str): filename
+        filepath (str): filepath
+        itemid (int): itemid
+        license (str): license
+        author (str): author
+        source (str): source
+        filesize (int): filesize
+    """
+
+    component: str
+    contextid: int
+    userid: str
+    filearea: str
+    filename: str
+    filepath: str
+    itemid: int
+    license: str
+    author: str
+    source: str
+    filesize: int

--- a/moodle/upload/upload.py
+++ b/moodle/upload/upload.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from moodle import BaseMoodle
+from . import File
+
+
+class Upload(BaseMoodle):
+    def __call__(
+        self, *files, itemid: int = 0, filepath: str = "/"
+    ) -> List[File]:
+        """Uploads files to moodle.
+
+        Args:
+            files (file-like-objects, multiple): The files to upload.
+            moodlewsrestformat (str, optional): Expected format. Defaults to "json".
+            itemid (int, optional): itemid to upload into. Defaults to 0.
+            filepath (str, optional): file path under which to upload. Defaults to '/'.
+
+        Returns:
+            List[File]: The details for the uploaded files
+        """
+        data = self.moodle.post_upload(*files, itemid=itemid, filepath=filepath)
+        return self._trs(File, data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def domain() -> str:
 @fixture
 def moodle(domain: str) -> Moodle:
     username = "manager"
-    password = "moodle2024"
+    password = "moodle25"
     return Moodle.login(domain, username, password)
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,14 @@
+from moodle import Moodle
+from moodle.upload import File
+
+
+class TestUpload:
+    def test_upload(self, moodle: Moodle):
+        files = moodle.upload(
+            ('LICENSE', open('LICENSE', 'rb')),
+        )
+        assert type(files) == list
+        assert len(files) == 1
+        for f in files:
+            assert isinstance(f, File)
+            assert f.filename == 'LICENSE'


### PR DESCRIPTION
(again based on #24)

This PR adds the ability to use the [file upload endpoint](https://moodledev.io/docs/5.0/apis/subsystems/external/files#file-upload) directly through `Moodle` instances:

```py
result = moodle.upload(
    ('filename.txt', open('./filename.txt', 'rb')),
)
result.filename  # filename.txt
result.itemid    # can be used e.g. to call mod_assign_save_submission, to add files to the submission
```

Since file uploads go through a separate endpoint (`/webservice/upload.php` instead of `/webservice/rest/server.php`), I added a method to the `Mdl` base class, and an exception in case the URL can't be determined (for _very_ nonstandard Moodle setups). The user facing API mirrors the other modules, with an `Upload` class extending `BaseMoodle`. Since there are no other methods, I used `__call__()`. If you don't agree with any of these decisions, I'd be happy to adjust the code, or accept your adjustments.

I also added a test case to make sure the code works.