### PR TITLE
Correct to_dict to flat multilevel dictionaries

### DIFF
--- a/moodle/utils/helper.py
+++ b/moodle/utils/helper.py
@@ -25,7 +25,11 @@ def to_dict(data: Any, name: str = "") -> Any:
             val = to_dict(val)
             if isinstance(val, dict):
                 for key, value in val.items():
-                    out[f"{name}[{idx}][{key}]"] = val[key]
+                    if "[" in key:
+                        pos = key.index("[")
+                        out[f"{name}[{idx}][{key[:pos]}]{key[pos:]}"] = val[key]
+                    else:
+                        out[f"{name}[{idx}][{key}]"] = val[key]
             else:
                 out_key = name
                 # Check if data required name prefix


### PR DESCRIPTION
The `to_dict` function fails when flattening multi-level dictionaries. For example:

```python
from moodle.utils.helper import to_dict

user_fields = {
    "username": "myusername",
    "auth": "email",
    "password": "TopSecretPassword",
    "firstname": "Name",
    "lastname": "Surname",
    "email": "myemail@example.com",
    "idnumber": "1001",
    "customfields": [{"type": "mycustomfield", "value": "example value"}],
}

to_dict({"users": [user_fields]})
```

This will generate the following output:

```
{'users[0][username]': 'myusername',
 'users[0][auth]': 'email',
 'users[0][password]': 'TopSecretPassword',
 'users[0][firstname]': 'Name',
 'users[0][lastname]': 'Surname',
 'users[0][email]': 'myemail@example.com',
 'users[0][idnumber]': '1001',
 'users[0][customfields[0][type]]': 'mycustomfield',
 'users[0][customfields[0][value]]': 'example value'}
```

However, the correct output should be like this:

```
{'users[0][username]': 'myusername',
 'users[0][auth]': 'email',
 'users[0][password]': 'TopSecretPassword',
 'users[0][firstname]': 'Name',
 'users[0][lastname]': 'Surname',
 'users[0][email]': 'myemail@example.com',
 'users[0][idnumber]': '1001',
 'users[0][customfields][0][type]': 'mycustomfield',
 'users[0][customfields][0][value]': 'example value'}
```

Note the difference in the last two lines of each output.
